### PR TITLE
Expose other BAM default ports

### DIFF
--- a/wso2am/1.8.0/Dockerfile
+++ b/wso2am/1.8.0/Dockerfile
@@ -40,8 +40,7 @@ COPY assets/_files/${WSO2_FOLDER_NAME}/repository/conf/api-manager.xml /opt/${WS
 COPY assets/_files/${WSO2_FOLDER_NAME}/repository/conf/datasources/master-datasources.xml /opt/${WSO2_FOLDER_NAME}/repository/conf/datasources/master-datasources.xml
 
 # Carbon ports (Offset +0)
-EXPOSE 9443
-EXPOSE 8280
+EXPOSE 9443 9763 8280 8243 7711 10397
 
 # Expose WSO2 repository folder to Host
 VOLUME ["/opt/${WSO2_FOLDER_NAME}/repository/deployment/server"]

--- a/wso2am/1.9.1/Dockerfile
+++ b/wso2am/1.9.1/Dockerfile
@@ -40,8 +40,7 @@ COPY assets/_files/${WSO2_FOLDER_NAME}/repository/conf/api-manager.xml /opt/${WS
 COPY assets/_files/${WSO2_FOLDER_NAME}/repository/conf/datasources/master-datasources.xml /opt/${WSO2_FOLDER_NAME}/repository/conf/datasources/master-datasources.xml
 
 # Carbon ports (Offset +0)
-EXPOSE 9443
-EXPOSE 8280
+EXPOSE 9443 9763 8280 8243 7711 10397
 
 # Expose WSO2 repository folder to Host
 VOLUME ["/opt/${WSO2_FOLDER_NAME}/repository/deployment/server"]

--- a/wso2am/latest/Dockerfile
+++ b/wso2am/latest/Dockerfile
@@ -40,8 +40,7 @@ COPY assets/_files/${WSO2_FOLDER_NAME}/repository/conf/api-manager.xml /opt/${WS
 COPY assets/_files/${WSO2_FOLDER_NAME}/repository/conf/datasources/master-datasources.xml /opt/${WSO2_FOLDER_NAME}/repository/conf/datasources/master-datasources.xml
 
 # Carbon ports (Offset +0)
-EXPOSE 9443
-EXPOSE 8280
+EXPOSE 9443 9763 8280 8243 7711 10397
 
 # Expose WSO2 repository folder to Host
 VOLUME ["/opt/${WSO2_FOLDER_NAME}/repository/deployment/server"]

--- a/wso2bam/2.5.0/Dockerfile
+++ b/wso2bam/2.5.0/Dockerfile
@@ -37,8 +37,7 @@ COPY assets/_files/${WSO2_FOLDER_NAME}/repository/conf/carbon.xml /opt/${WSO2_FO
 COPY assets/_files/${WSO2_FOLDER_NAME}/repository/conf/tomcat/carbon/WEB-INF/web.xml /opt/${WSO2_FOLDER_NAME}/repository/conf/tomcat/carbon/WEB-INF/web.xml
 
 # Carbon ports (Offset +0)
-EXPOSE 9443
-EXPOSE 8280
+EXPOSE 9443 9763 9160 7711 7611 21000
 
 # Expose WSO2 repository folder to Host
 VOLUME ["/opt/${WSO2_FOLDER_NAME}/repository/deployment/server"]

--- a/wso2bam/latest/Dockerfile
+++ b/wso2bam/latest/Dockerfile
@@ -37,8 +37,7 @@ COPY assets/_files/${WSO2_FOLDER_NAME}/repository/conf/carbon.xml /opt/${WSO2_FO
 COPY assets/_files/${WSO2_FOLDER_NAME}/repository/conf/tomcat/carbon/WEB-INF/web.xml /opt/${WSO2_FOLDER_NAME}/repository/conf/tomcat/carbon/WEB-INF/web.xml
 
 # Carbon ports (Offset +0)
-EXPOSE 9443
-EXPOSE 8280
+EXPOSE 9443 9763 9160 7711 7611 21000
 
 # Expose WSO2 repository folder to Host
 VOLUME ["/opt/${WSO2_FOLDER_NAME}/repository/deployment/server"]


### PR DESCRIPTION
This PR updates the BAM Dockerfile to expose other default ports needed for the it to function correctly. Refer WSO2 docs [here](https://docs.wso2.com/display/Carbon410/Default+Ports+of+WSO2+Productswq). Hope it helps.
